### PR TITLE
Jupyter-ydoc 0.2.3 (mk2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @davidbrochart
+* @conda-forge/jupyter_server @davidbrochart

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-About jupyter_ydoc
-==================
+About jupyter_ydoc-feedstock
+============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_ydoc-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/jupyter-server/jupyter_ydoc
 
 Package license: BSD-3-Clause
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/jupyter_ydoc-feedstock/blob/main/LICENSE.txt)
-
 Summary: Document structures for collaborative editing using Ypy
 
-Development: https://github.com/jupyter-server/jupyter_ydoc
+Documentation: https://jupyter-ydoc.readthedocs.io
 
 Current build status
 ====================
@@ -145,5 +145,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@conda-forge/jupyter_server](https://github.com/conda-forge/jupyter_server/)
 * [@davidbrochart](https://github.com/davidbrochart/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,8 +48,9 @@ test:
     - pip check
     - export YARN_CACHE_FOLDER="$SRC_DIR/.yarn-cache"  # [unix]
     - set YARN_CACHE_FOLDER="%SRC_DIR%/.yarn-cache"  # [win]
-    - cd src && yarn --frozen-lockfile --ignore-scripts && cd javascript && yarn build && cd ../..
-    - cd src && pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=70
+    - cd src/javascript && yarn --frozen-lockfile && cd ../tests && yarn --frozen-lockfile
+    - cd "$SRC_DIR" || cd "%SRC_DIR"
+    - pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=70
     # - mypy -p jupyter_ydoc
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,9 +48,13 @@ test:
     - pip check
     - export YARN_CACHE_FOLDER="$SRC_DIR/.yarn-cache"  # [unix]
     - set YARN_CACHE_FOLDER="%SRC_DIR%/.yarn-cache"  # [win]
-    - cd src/javascript && yarn --frozen-lockfile && cd ../tests && yarn --frozen-lockfile && yarn add "file:../javascript"
-    - cd "$SRC_DIR" || cd "%SRC_DIR"
-    - pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=70
+    - cd src/javascript && yarn && yarn build && yarn link --link-folder=../../.yarn-links
+    - cd "$SRC_DIR"  # [unix]
+    - cd "%SRC_DIR%"  # [win]
+    - cd src/tests && yarn && yarn link "@jupyter/ydoc" --link-folder=../../.yarn-links
+    - cd "$SRC_DIR"  # [unix]
+    - cd "%SRC_DIR%"  # [win]
+    - pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=56
     # - mypy -p jupyter_ydoc
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ requirements:
 test:
   source_files:
     - src/javascript
-    - src/lerna.json
     - src/package.json
     - src/tests
   requires:
@@ -49,7 +48,7 @@ test:
     - pip check
     - export YARN_CACHE_FOLDER="$SRC_DIR/.yarn-cache"  # [unix]
     - set YARN_CACHE_FOLDER="%SRC_DIR%/.yarn-cache"  # [win]
-    - cd src && yarn --frozen-lockfile --ignore-scripts && yarn lerna bootstrap && yarn build && cd ..
+    - cd src && yarn --frozen-lockfile --ignore-scripts && cd javascript && yarn build && cd ../..
     - cd src && pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=70
     # - mypy -p jupyter_ydoc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
     - pip check
     - export YARN_CACHE_FOLDER="$SRC_DIR/.yarn-cache"  # [unix]
     - set YARN_CACHE_FOLDER="%SRC_DIR%/.yarn-cache"  # [win]
-    - cd src/javascript && yarn --frozen-lockfile && cd ../tests && yarn --frozen-lockfile
+    - cd src/javascript && yarn --frozen-lockfile && cd ../tests && yarn --frozen-lockfile && yarn add "file:../javascript"
     - cd "$SRC_DIR" || cd "%SRC_DIR"
     - pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=70
     # - mypy -p jupyter_ydoc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.4" %}
+{% set version = "0.2.3" %}
 
 package:
   name: jupyter_ydoc
@@ -7,10 +7,10 @@ package:
 source:
   - folder: dist
     url: https://pypi.io/packages/source/j/jupyter_ydoc/jupyter_ydoc-{{ version }}.tar.gz
-    sha256: 5a2262e70bf004b82cc6ce71675e9330aa058fe30db2e87cd8125ad4dd1ae4e1
+    sha256: 98db7785215873c64d7dfcb1b741f41df11994c4b3d7e2957e004b392d6f11ea
   - folder: src
     url: https://github.com/jupyter-server/jupyter_ydoc/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 0f0c6064f67e07112f7982dc5ea68b2a44c2f7b39003ade3f64c7a99ba7e7f99
+    sha256: fbc990fd64651310290aa994389ebe3d3b596c45f613cbb567184256d304e218
 
 build:
   noarch: python
@@ -26,7 +26,7 @@ requirements:
   run:
     - importlib_metadata >=3.6
     - python >=3.7
-    - y-py >=0.6.0,<0.7.0
+    - y-py >=0.5.3,<0.6.0
 
 test:
   source_files:
@@ -41,7 +41,7 @@ test:
     - pytest-cov
     - websockets >=10.0
     - yarn <2
-    - ypy-websocket >=0.8.3,<0.9.0
+    - ypy-websocket >=0.3.1,<0.4.0
     # - mypy
   imports:
     - jupyter_ydoc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,6 @@ test:
     - websockets >=10.0
     - yarn <2
     - ypy-websocket >=0.3.1,<0.4.0
-    # - mypy
   imports:
     - jupyter_ydoc
   commands:
@@ -55,7 +54,6 @@ test:
     - cd "$SRC_DIR"  # [unix]
     - cd "%SRC_DIR%"  # [win]
     - pytest -vv --asyncio-mode=auto --cov=jupyter_ydoc --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=56
-    # - mypy -p jupyter_ydoc
 
 about:
   home: https://github.com/jupyter-server/jupyter_ydoc


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- _actually_ blocks https://github.com/conda-forge/jupyterlab-feedstock/pull/367
- reboot of #25 (wasn't picking up commits?)

Changes:
- roll back all nodejs stuff
  - some tests/connections apparently not ready for ipv6... might be able to force with `127.0.0.1` vs `localhost`
- roll back lerna stuff (yay) but more fiddly (boo)